### PR TITLE
Add GitHub Actions to build and deploy site

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,33 @@
+name: build
+
+on:
+  pull_request: {}
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 11
+
+      - run: mvn verify javadoc:javadoc
+
+      - name: Deploy docs to website
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: site
+          FOLDER: target/site/apidocs
+          TARGET_FOLDER: docs/latest/
+          CLEAN: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,29 @@
+name: release
+
+on:
+  push:
+    tags:
+      - '**'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 11
+
+      - run: mvn javadoc:javadoc
+
+      - name: Deploy docs to website
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: site
+          FOLDER: target/site/apidocs
+          TARGET_FOLDER: docs/1.x/
+          CLEAN: true


### PR DESCRIPTION
This will deploy "main" under `docs/latest/` and deploy tags to `docs/1.x/` on the "site" branch.

# !!! Prerequisites !!!

_Before_ this PR lands you need to create a `site` branch. The easiest way to do that is these steps:
```
$ git switch --orphan site
$ touch .nojekyll
$ git add .nojekyll
$ git commit -m "Initial site"
$ git push origin site
```
This will create a new branch with no shared history to `main` and no index. It will add a `.nojekyll` file which tells GitHub not to try and build a Jekyll website on the branch (once we eventually enable GitHub pages). And it pushes that new branch up to GitHub.

Next, you will need to visit https://github.com/google/TestParameterInjector/settings/pages and enable GitHub pages on the `site` branch in the root (`/`). If successful, you should be able to visit/curl https://google.github.io/TestParameterInjector/.nojekyll and get a zero-byte response rather than an HTTP 404.

Once that is working, this PR can be merged. After a minute or two, you should be able to visit https://google.github.io/TestParameterInjector/docs/latest/ for the latest API docs. After the next tag is pushed, https://google.github.io/TestParameterInjector/docs/1.x/ will work. You could even consider deleting and re-pushing the most recent tag to simply trigger deploying the "1.x" docs.

Bonus: All pull requests will now have `mvn verify javadoc:javadoc` run on them to validate they build, the tests pass, and the javadoc can be built!

I have also added a `dependabot.yaml` file which will automatically keep the versions in the GitHub Actions up-to-date.

Let me know if you have any questions.

Closes #1.