### PR TITLE
Add maven caching to the `build` GitHub action.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,8 +33,9 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
+          cache: maven
 
-      - run: mvn verify javadoc:javadoc
+      - run: mvn --update-snapshots -B verify javadoc:javadoc
 
       - name: Deploy docs to website
         if: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
This should speed up the action by avoiding downloading of all dependencies for every build.