### PR TITLE
Add an `exclude` attribute in `@TestParameter` to exclude enum values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ The following examples show most of the supported types. See the `@TestParameter
 // Enums
 @TestParameter AnimalEnum a; // Implies all possible values of AnimalEnum
 @TestParameter({"CAT", "DOG"}) AnimalEnum a; // Implies AnimalEnum.CAT and AnimalEnum.DOG.
+@TestParameter(exclude = {"CAT", "DOG"}) AnimalEnum a; // Excludes AnimalEnum.CAT and AnimalEnum.DOG.
 
 // Strings
 @TestParameter({"cat", "dog"}) String animalName;

--- a/junit4/src/test/java/com/google/testing/junit/testparameterinjector/TestParameterTest.java
+++ b/junit4/src/test/java/com/google/testing/junit/testparameterinjector/TestParameterTest.java
@@ -127,27 +127,28 @@ public class TestParameterTest {
     public void test(
         @TestParameter TestEnum enumParameterA,
         @TestParameter({"TWO", "THREE"}) TestEnum enumParameterB,
+        @TestParameter(exclude = {"TWO", "THREE"}) TestEnum enumParameterC,
         @TestParameter({"!!binary 'ZGF0YQ=='", "data2"}) byte[] bytes) {
       testedParameters.add(
-          String.format("%s:%s:%s", enumParameterA, enumParameterB, new String(bytes)));
+          String.format("%s:%s:%s:%s", enumParameterA, enumParameterB, enumParameterC, new String(bytes)));
     }
 
     @AfterClass
     public static void completedAllParameterizedTests() {
       assertThat(testedParameters)
           .containsExactly(
-              "ONE:TWO:data",
-              "ONE:THREE:data",
-              "TWO:TWO:data",
-              "TWO:THREE:data",
-              "THREE:TWO:data",
-              "THREE:THREE:data",
-              "ONE:TWO:data2",
-              "ONE:THREE:data2",
-              "TWO:TWO:data2",
-              "TWO:THREE:data2",
-              "THREE:TWO:data2",
-              "THREE:THREE:data2");
+              "ONE:TWO:ONE:data",
+              "ONE:THREE:ONE:data",
+              "TWO:TWO:ONE:data",
+              "TWO:THREE:ONE:data",
+              "THREE:TWO:ONE:data",
+              "THREE:THREE:ONE:data",
+              "ONE:TWO:ONE:data2",
+              "ONE:THREE:ONE:data2",
+              "TWO:TWO:ONE:data2",
+              "TWO:THREE:ONE:data2",
+              "THREE:TWO:ONE:data2",
+              "THREE:THREE:ONE:data2");
     }
   }
 

--- a/junit5/src/main/java/com/google/testing/junit/testparameterinjector/junit5/TestParameter.java
+++ b/junit5/src/main/java/com/google/testing/junit/testparameterinjector/junit5/TestParameter.java
@@ -15,6 +15,8 @@
 package com.google.testing.junit.testparameterinjector.junit5;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -22,6 +24,7 @@ import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.toList;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Primitives;
 import com.google.protobuf.MessageLite;
 import com.google.testing.junit.testparameterinjector.junit5.TestParameter.InternalImplementationOfThisParameter;
@@ -116,6 +119,18 @@ public @interface TestParameter {
   Class<? extends TestParameterValuesProvider> valuesProvider() default
       DefaultTestParameterValuesProvider.class;
 
+  /**
+   * Excludes an array of stringified values for the annotated type.
+   *
+   * <p>Types that are supported:
+   *
+   * <ul>
+   *   <li>Enum value: Specified as a String that can be parsed by {@code Enum.valueOf()}
+   * </ul>
+   * @return
+   */
+  String[] exclude() default {};
+
   /** Interface for custom providers of test parameter values. */
   interface TestParameterValuesProvider {
     List<?> provideValues();
@@ -153,7 +168,13 @@ public @interface TestParameter {
         return getValuesFromProvider(annotation.valuesProvider());
       } else {
         if (Enum.class.isAssignableFrom(parameterClass)) {
-          return ImmutableList.copyOf(parameterClass.asSubclass(Enum.class).getEnumConstants());
+          ImmutableSet<Enum> excludedEnums = stream(annotation.exclude())
+              .map(excludedEnumString ->
+                  ParameterValueParsing.parseEnum(excludedEnumString, parameterClass))
+              .collect(toImmutableSet());
+          return stream(parameterClass.asSubclass(Enum.class).getEnumConstants())
+              .filter(e -> !excludedEnums.contains(e))
+              .collect(toImmutableList());
         } else if (Primitives.wrap(parameterClass).equals(Boolean.class)) {
           return ImmutableList.of(false, true);
         } else {

--- a/junit5/src/test/java/com/google/testing/junit/testparameterinjector/junit5/TestParameterInjectorJUnit5Test.java
+++ b/junit5/src/test/java/com/google/testing/junit/testparameterinjector/junit5/TestParameterInjectorJUnit5Test.java
@@ -127,8 +127,9 @@ class TestParameterInjectorJUnit5Test {
 
     @TestParameterInjectorTest
     void withParameter_success(
-        @TestParameter({"2", "xyz"}) String name, @TestParameter boolean bool) {
-      storeTestParametersForThisTest(name, bool);
+        @TestParameter({"2", "xyz"}) String name, @TestParameter boolean bool,
+        @TestParameter(exclude = {"THREE"}) TestEnum enumParameter) {
+      storeTestParametersForThisTest(name, bool, enumParameter);
     }
 
     @Override
@@ -138,10 +139,14 @@ class TestParameterInjectorJUnit5Test {
           .put("withoutParameters", "")
           .put("withParameters_success[{name: 1, number: 3.3}]", "1:3.3")
           .put("withParameters_success[{name: abc, number: 5}]", "abc:5.0")
-          .put("withParameter_success[2,bool=false]", "2:false")
-          .put("withParameter_success[2,bool=true]", "2:true")
-          .put("withParameter_success[xyz,bool=false]", "xyz:false")
-          .put("withParameter_success[xyz,bool=true]", "xyz:true")
+          .put("withParameter_success[2,bool=false,ONE]", "2:false:ONE")
+          .put("withParameter_success[2,bool=false,TWO]", "2:false:TWO")
+          .put("withParameter_success[2,bool=true,ONE]", "2:true:ONE")
+          .put("withParameter_success[2,bool=true,TWO]", "2:true:TWO")
+          .put("withParameter_success[xyz,bool=false,ONE]", "xyz:false:ONE")
+          .put("withParameter_success[xyz,bool=false,TWO]", "xyz:false:TWO")
+          .put("withParameter_success[xyz,bool=true,ONE]", "xyz:true:ONE")
+          .put("withParameter_success[xyz,bool=true,TWO]", "xyz:true:TWO")
           .build();
     }
   }


### PR DESCRIPTION
Currently the `exclude` attribute in `@TestParameter` only supports
enums since it may not make any sense to support other types. It should
be fairly easy to add support for other types if needed.