### PR TITLE
Bump protobuf dependency 3.0.1 -> 3.20.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,8 +141,8 @@
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-lite</artifactId>
-      <version>3.0.1</version>
+      <artifactId>protobuf-javalite</artifactId>
+      <version>3.20.0</version>
     </dependency>
     <dependency>
       <groupId>org.yaml</groupId>


### PR DESCRIPTION
The older version of this transitive dependency may not be compatible with other project dependencies which may expect newer version. Build system won't auto-resolve to newer version since artifact id is different.

Personally bumped into this kind of issue while trying to use Firebase perf in my project: https://github.com/firebase/firebase-android-sdk/issues/1907


