### PR TITLE
Replace deprecated call to org.yaml.snakeyaml.constructor.SafeConstructor

### DIFF
--- a/junit4/src/main/java/com/google/testing/junit/testparameterinjector/ParameterValueParsing.java
+++ b/junit4/src/main/java/com/google/testing/junit/testparameterinjector/ParameterValueParsing.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import javax.annotation.Nullable;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 
@@ -43,7 +44,7 @@ final class ParameterValueParsing {
 
   static boolean isValidYamlString(String yamlString) {
     try {
-      new Yaml(new SafeConstructor()).load(yamlString);
+      new Yaml(new SafeConstructor(new LoaderOptions())).load(yamlString);
       return true;
     } catch (RuntimeException e) {
       return false;
@@ -55,7 +56,7 @@ final class ParameterValueParsing {
   }
 
   static Object parseYamlStringToObject(String yamlString) {
-    return new Yaml(new SafeConstructor()).load(yamlString);
+    return new Yaml(new SafeConstructor(new LoaderOptions())).load(yamlString);
   }
 
   @SuppressWarnings({"unchecked"})

--- a/junit5/src/main/java/com/google/testing/junit/testparameterinjector/junit5/ParameterValueParsing.java
+++ b/junit5/src/main/java/com/google/testing/junit/testparameterinjector/junit5/ParameterValueParsing.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import javax.annotation.Nullable;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 
@@ -43,7 +44,7 @@ final class ParameterValueParsing {
 
   static boolean isValidYamlString(String yamlString) {
     try {
-      new Yaml(new SafeConstructor()).load(yamlString);
+      new Yaml(new SafeConstructor(new LoaderOptions())).load(yamlString);
       return true;
     } catch (RuntimeException e) {
       return false;
@@ -55,7 +56,7 @@ final class ParameterValueParsing {
   }
 
   static Object parseYamlStringToObject(String yamlString) {
-    return new Yaml(new SafeConstructor()).load(yamlString);
+    return new Yaml(new SafeConstructor(new LoaderOptions())).load(yamlString);
   }
 
   @SuppressWarnings({"unchecked"})


### PR DESCRIPTION
Calling `SafeConstructor()`is deprecated in SnakeYaml 1.x und was removed in 2.0, making TestParameterInjector fail with this version on the class path:

https://github.com/snakeyaml/snakeyaml/commit/3e755d254aeaa902675053047fd53368a175565a#diff-2f3798f3a205b35967d24a4611fce96716257d3a809dc4a0e3455b46ac7441f5