### PR TITLE
Bump org.yaml.snakeyaml 1.27 -> 2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.27</version>
+      <version>2.0</version>
     </dependency>
 
     <!-- Test dependencies -->


### PR DESCRIPTION
`org.yaml.snakeyaml` library contains multiple security vulnerabilities:
https://mvnrepository.com/artifact/org.yaml/snakeyaml/1.27
Bumping this dependency to the latest version
Release notes:
https://bitbucket.org/snakeyaml/snakeyaml/wiki/Changes

This release contains some backward incompatible changes
I went through all the usage of snakeyaml, so I couldn't find any issues. But I'm not able to build and run tests, so I'm not 100% sure if this change doesn't break something
