### PR TITLE
Add license information to each artifact

### DIFF
--- a/junit4/pom.xml
+++ b/junit4/pom.xml
@@ -30,6 +30,14 @@
 
   <name>TestParameterInjector for JUnit4</name>
 
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
   <dependencies>
     <!-- Compile-time dependencies -->
     <dependency>

--- a/junit5/pom.xml
+++ b/junit5/pom.xml
@@ -30,6 +30,14 @@
 
   <name>TestParameterInjector for JUnit5</name>
 
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
   <dependencies>
     <!-- Compile-time dependencies -->
     <dependency>


### PR DESCRIPTION
Our repository uses this library as it is a dependency of robolectric. Our license checker is unhappy as this artifact does not declare its license.