### PR TITLE
Fix flaky tests in TestParameterInjectorKotlinTest by enforcing field processing order

### DIFF
--- a/junit4/src/main/java/com/google/testing/junit/testparameterinjector/TestParameterMethodProcessor.java
+++ b/junit4/src/main/java/com/google/testing/junit/testparameterinjector/TestParameterMethodProcessor.java
@@ -50,6 +50,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.regex.Matcher;
@@ -461,7 +462,12 @@ class TestParameterMethodProcessor implements TestMethodProcessor {
       Class<?> testClass) {
     List<AnnotationWithMetadata> annotations =
         FluentIterable.from(listWithParents(testClass))
-            .transformAndConcat(c -> Arrays.asList(c.getDeclaredFields()))
+            .transformAndConcat(
+                c -> {
+                  Field[] fields = c.getDeclaredFields();
+                  Arrays.sort(fields, Comparator.comparing(Field::getName));
+                  return Arrays.asList(fields);
+                })
             .transformAndConcat(
                 field ->
                     maybeGetTestParameter(field.getAnnotations())


### PR DESCRIPTION
### Description
Modified `TestParameterMethodProcessor.getFieldValueHolders` to sort the fields returned by `Class.getDeclaredFields()` alphabetically. This ensures that the order in which `@TestParameter` annotated fields are processed is deterministic.

### Motivation
NonDex detected test flakiness in:
-  `com.google.testing.junit.testparameterinjector.TestParameterInjectorKotlinTest#test_success[TestParameter_PrimaryConstructorParamMixedWithField]`
- `com.google.testing.junit.testparameterinjector.TestParameterMethodProcessorTest#test_success[MultipleAnnotatedFieldsAndParameters]`

This is due to the non-deterministic order of fields returned by `Class.getDeclaredFields()`. The `TestParameterInjector` uses this order to generate test names (for example test[param1=val1, param2=val2]). When the order of fields changes the generated test names change, causing assertions that expect a specific order to fail. Sorting the fields ensures a consistent order regardless of JVM implementation or runtime conditions. NonDex output with the failure attached.
[nondex_output__.txt](https://github.com/user-attachments/files/24133774/nondex_output__.txt)
